### PR TITLE
added error handling for core functions

### DIFF
--- a/core/recipient/main.go
+++ b/core/recipient/main.go
@@ -17,7 +17,12 @@ import (
 func NewMeta() (outputJsonString string) {
 
 	k, K := utils.SECP256k_Gen1G1KeyPair()
-	v, V, _ := utils.BN254_GenG1KeyPair()
+	v, V, err := utils.BN254_GenG1KeyPair()
+
+	if err != nil {
+		fmt.Errorf("error generating K and V: %v", err)
+		return
+	}
 
 	var recipientNewMeta RecipientNewMeta
 	recipientNewMeta.PK_k = k.Text(16)
@@ -25,13 +30,22 @@ func NewMeta() (outputJsonString string) {
 	recipientNewMeta.K = utils.PackXY(K.X.String(), K.Y.String())
 	recipientNewMeta.V = utils.PackXY(V.X.String(), V.Y.String())
 
-	tmp, _ := json.Marshal(recipientNewMeta)
+	tmp, err := json.Marshal(recipientNewMeta)
+
+	if err != nil {
+		fmt.Errorf("error marshalling new recipient meta: %v", err)
+		return
+	}
+
 	return string(tmp)
 }
 
 func GetMeta(inputJsonString string) (outputJsonString string) {
 	var recipientInputData RecipientInputMeta
-	json.Unmarshal([]byte(inputJsonString), &recipientInputData)
+	if err := json.Unmarshal([]byte(inputJsonString), &recipientInputData); err != nil {
+		fmt.Errorf("error while unmarshalling input string: %v", err)
+		return
+	}
 
 	var recipientNewMeta RecipientNewMeta
 
@@ -39,7 +53,13 @@ func GetMeta(inputJsonString string) (outputJsonString string) {
 	recipientNewMeta.PK_v = recipientInputData.PK_v
 
 	var k SECP256K1_fr.Element
-	kBytes, _ := hex.DecodeString(recipientNewMeta.PK_k)
+	kBytes, err := hex.DecodeString(recipientNewMeta.PK_k)
+
+	if err != nil {
+		fmt.Errorf("error decoding string for k: %v", err)
+		return
+	}
+
 	k.Unmarshal(kBytes)
 	var k_asBigInt big.Int
 	k.BigInt(&k_asBigInt)
@@ -47,7 +67,13 @@ func GetMeta(inputJsonString string) (outputJsonString string) {
 	K.ScalarMultiplicationBase(&k_asBigInt)
 
 	var v BN254_fr.Element
-	vBytes, _ := hex.DecodeString(recipientNewMeta.PK_v)
+	vBytes, err := hex.DecodeString(recipientNewMeta.PK_v)
+
+	if err != nil {
+		fmt.Errorf("error decoding string for v: %v", err)
+		return
+	}
+
 	v.Unmarshal(vBytes)
 	var v_asBigInt big.Int
 	v.BigInt(&v_asBigInt)
@@ -57,7 +83,13 @@ func GetMeta(inputJsonString string) (outputJsonString string) {
 	recipientNewMeta.K = utils.PackXY(K.X.String(), K.Y.String())
 	recipientNewMeta.V = utils.PackXY(V.X.String(), V.Y.String())
 
-	tmp, _ := json.Marshal(recipientNewMeta)
+	tmp, err := json.Marshal(recipientNewMeta)
+
+	if err != nil {
+		fmt.Errorf("error marshaling new recipient meta: %v", err)
+		return
+	}
+
 	return string(tmp)
 }
 
@@ -66,7 +98,10 @@ func Scan(inputJsonString string) (outputJsonString string) {
 	fmt.Println(inputJsonString)
 
 	var recipientInputData RecipientInputData
-	json.Unmarshal([]byte(inputJsonString), &recipientInputData)
+	if err := json.Unmarshal([]byte(inputJsonString), &recipientInputData); err != nil {
+		fmt.Errorf("error marshalling input string: %v", err)
+		return
+	}
 
 	fmt.Println("recipientInputData", recipientInputData)
 
@@ -88,13 +123,25 @@ func Scan(inputJsonString string) (outputJsonString string) {
 	}
 
 	var k SECP256K1_fr.Element
-	kBytes, _ := hex.DecodeString(recipientInputData.PK_k)
+	kBytes, err := hex.DecodeString(recipientInputData.PK_k)
+
+	if err != nil {
+		fmt.Errorf("error decoding string for k: %v", err)
+		return
+	}
+
 	k.Unmarshal(kBytes)
 	var k_asBigInt big.Int
 	k.BigInt(&k_asBigInt)
 
 	var v BN254_fr.Element
-	vBytes, _ := hex.DecodeString(recipientInputData.PK_v)
+	vBytes, err := hex.DecodeString(recipientInputData.PK_v)
+
+	if err != nil {
+		fmt.Errorf("error decoding string for v: %v", err)
+		return
+	}
+
 	v.Unmarshal(vBytes)
 	var v_asBigInt big.Int
 	v.BigInt(&v_asBigInt)
@@ -133,7 +180,13 @@ func Scan(inputJsonString string) (outputJsonString string) {
 		recipientOutputData.SpendingPrivKeys = append(recipientOutputData.SpendingPrivKeys, "0x"+kb.Text(16))
 	}
 
-	tmp, _ := json.Marshal(recipientOutputData)
+	tmp, err := json.Marshal(recipientOutputData)
+
+	if err != nil {
+		fmt.Errorf("error marshalling recipient output data: %v", err)
+		return
+	}
+
 	return string(tmp)
 }
 
@@ -174,7 +227,13 @@ func computeSharedSecret(v *BN254_fr.Element, R *BN254.G1Affine) BN254.GT {
 	var G2Aff BN254.G2Affine
 	G2Aff.FromJacobian(&G2Jac)
 
-	P, _ := BN254.Pair([]BN254.G1Affine{productAffine}, []BN254.G2Affine{G2Aff})
+	P, err := BN254.Pair([]BN254.G1Affine{productAffine}, []BN254.G2Affine{G2Aff})
+
+	if err != nil {
+		fmt.Errorf("error while pairing calculates: %v", err)
+		// TODO: what can we return here
+		// return BN254.GT{} //would this suffice
+	}
 
 	return P
 }

--- a/core/recipient/main.go
+++ b/core/recipient/main.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"log"
 	"math/big"
 
 	BN254 "github.com/consensys/gnark-crypto/ecc/bn254"
@@ -20,8 +21,8 @@ func NewMeta() (outputJsonString string) {
 	v, V, err := utils.BN254_GenG1KeyPair()
 
 	if err != nil {
-		fmt.Errorf("error generating K and V: %v", err)
-		return
+		log.Printf("error generating K and V: %v", err)
+		panic(fmt.Errorf("error generating K and V: %v", err))
 	}
 
 	var recipientNewMeta RecipientNewMeta
@@ -33,8 +34,8 @@ func NewMeta() (outputJsonString string) {
 	tmp, err := json.Marshal(recipientNewMeta)
 
 	if err != nil {
-		fmt.Errorf("error marshalling new recipient meta: %v", err)
-		return
+		log.Printf("error marshalling new recipient meta: %v", err)
+		panic(fmt.Errorf("error marshalling new recipient meta: %v", err))
 	}
 
 	return string(tmp)
@@ -43,8 +44,8 @@ func NewMeta() (outputJsonString string) {
 func GetMeta(inputJsonString string) (outputJsonString string) {
 	var recipientInputData RecipientInputMeta
 	if err := json.Unmarshal([]byte(inputJsonString), &recipientInputData); err != nil {
-		fmt.Errorf("error while unmarshalling input string: %v", err)
-		return
+		log.Printf("error while unmarshalling input string: %v", err)
+		panic(fmt.Errorf("error while unmarshalling input string: %v", err))
 	}
 
 	var recipientNewMeta RecipientNewMeta
@@ -56,8 +57,8 @@ func GetMeta(inputJsonString string) (outputJsonString string) {
 	kBytes, err := hex.DecodeString(recipientNewMeta.PK_k)
 
 	if err != nil {
-		fmt.Errorf("error decoding string for k: %v", err)
-		return
+		log.Printf("error decoding string for k: %v", err)
+		panic(fmt.Errorf("error decoding string for k: %v", err))
 	}
 
 	k.Unmarshal(kBytes)
@@ -70,8 +71,8 @@ func GetMeta(inputJsonString string) (outputJsonString string) {
 	vBytes, err := hex.DecodeString(recipientNewMeta.PK_v)
 
 	if err != nil {
-		fmt.Errorf("error decoding string for v: %v", err)
-		return
+		log.Printf("error decoding string for v: %v", err)
+		panic(fmt.Errorf("error decoding string for v: %v", err))
 	}
 
 	v.Unmarshal(vBytes)
@@ -86,8 +87,8 @@ func GetMeta(inputJsonString string) (outputJsonString string) {
 	tmp, err := json.Marshal(recipientNewMeta)
 
 	if err != nil {
-		fmt.Errorf("error marshaling new recipient meta: %v", err)
-		return
+		log.Printf("error marshaling new recipient meta: %v", err)
+		panic(fmt.Errorf("error marshaling new recipient meta: %v", err))
 	}
 
 	return string(tmp)
@@ -99,8 +100,8 @@ func Scan(inputJsonString string) (outputJsonString string) {
 
 	var recipientInputData RecipientInputData
 	if err := json.Unmarshal([]byte(inputJsonString), &recipientInputData); err != nil {
-		fmt.Errorf("error marshalling input string: %v", err)
-		return
+		log.Printf("error marshalling input string: %v", err)
+		panic(fmt.Errorf("error marshalling input string: %v", err))
 	}
 
 	fmt.Println("recipientInputData", recipientInputData)
@@ -126,8 +127,8 @@ func Scan(inputJsonString string) (outputJsonString string) {
 	kBytes, err := hex.DecodeString(recipientInputData.PK_k)
 
 	if err != nil {
-		fmt.Errorf("error decoding string for k: %v", err)
-		return
+		log.Printf("error decoding string for k: %v", err)
+		panic(fmt.Errorf("error decoding string for k: %v", err))
 	}
 
 	k.Unmarshal(kBytes)
@@ -138,8 +139,8 @@ func Scan(inputJsonString string) (outputJsonString string) {
 	vBytes, err := hex.DecodeString(recipientInputData.PK_v)
 
 	if err != nil {
-		fmt.Errorf("error decoding string for v: %v", err)
-		return
+		log.Printf("error decoding string for v: %v", err)
+		panic(fmt.Errorf("error decoding string for v: %v", err))
 	}
 
 	v.Unmarshal(vBytes)
@@ -183,8 +184,8 @@ func Scan(inputJsonString string) (outputJsonString string) {
 	tmp, err := json.Marshal(recipientOutputData)
 
 	if err != nil {
-		fmt.Errorf("error marshalling recipient output data: %v", err)
-		return
+		log.Printf("error marshalling recipient output data: %v", err)
+		panic(fmt.Errorf("error marshalling recipient output data: %v", err))
 	}
 
 	return string(tmp)
@@ -230,9 +231,8 @@ func computeSharedSecret(v *BN254_fr.Element, R *BN254.G1Affine) BN254.GT {
 	P, err := BN254.Pair([]BN254.G1Affine{productAffine}, []BN254.G2Affine{G2Aff})
 
 	if err != nil {
-		fmt.Errorf("error while pairing calculates: %v", err)
-		// TODO: what can we return here
-		// return BN254.GT{} //would this suffice
+		log.Printf("error while pairing calculates: %v", err)
+		panic(fmt.Errorf("error while pairing calculates: %v", err))
 	}
 
 	return P

--- a/core/sender/main.go
+++ b/core/sender/main.go
@@ -3,6 +3,7 @@ package sender
 import (
 	"encoding/json"
 	"fmt"
+	"log"
 	"math/big"
 
 	BN254 "github.com/consensys/gnark-crypto/ecc/bn254"
@@ -19,8 +20,8 @@ func Send(inputJsonString string) (outputJsonString string) {
 
 	var senderInputData SenderInputData
 	if err := json.Unmarshal([]byte(inputJsonString), &senderInputData); err != nil {
-		fmt.Errorf("error while unmarshalling input string: %v", err)
-		return
+		log.Printf("error while unmarshalling input string: %v", err)
+		panic(fmt.Errorf("error while unmarshalling input string: %v", err))
 	}
 
 	fmt.Printf("SenderInputData %+v\n", senderInputData)
@@ -43,8 +44,8 @@ func Send(inputJsonString string) (outputJsonString string) {
 	R, err := utils.BN254_CalcG1PubKey(r)
 
 	if err != nil {
-		fmt.Errorf("error while calculating R: %v", err)
-		return
+		log.Printf("error while calculating R: %v", err)
+		panic(fmt.Errorf("error while calculating R: %v", err))
 	}
 
 	senderOutputData.R = utils.PackXY(R.X.String(), R.Y.String())
@@ -60,8 +61,8 @@ func Send(inputJsonString string) (outputJsonString string) {
 	jsonData, err := json.Marshal(senderOutputData)
 
 	if err != nil {
-		fmt.Errorf("error while marshalling sender output data: %v", err)
-		return
+		log.Printf("error while marshalling sender output data: %v", err)
+		panic(fmt.Errorf("error while marshalling sender output data: %v", err))
 	}
 
 	return string(jsonData)
@@ -96,9 +97,8 @@ func computeSharedSecret(r *BN254_fr.Element, V *BN254.G1Affine) BN254.GT {
 	P, err := BN254.Pair([]BN254.G1Affine{productAffine}, []BN254.G2Affine{G2Aff})
 
 	if err != nil {
-		fmt.Errorf("error while pairing calculates: %v", err)
-		// TODO: Same thing here
-		// return BN254.GT{}
+		log.Printf("error while pairing calculates: %v", err)
+		panic(fmt.Errorf("error while pairing calculates: %v", err))
 	}
 
 	return P


### PR DESCRIPTION
Output seems correct after the changes 


```js
{"k":"1072809b97a3f1dbeab2142394e224c69171c0943afbfefd8e0661b003f3e76a","v":"1c6b9bbb697af10c10841daf2f66c34f35119df99210f0a217d7576641a3c4bd","K":"12441330761073902362665870877411039194406913991527867894825343377465888911436.46098634706424153770461318034056899255536118904510923943565444055909322001987","V":"8102025673725356318677291182437916572141609255897970301275085776048145857154.556392429964288978869362748540071319936808983044189432587667189241665581092"}
{"k":"1072809b97a3f1dbeab2142394e224c69171c0943afbfefd8e0661b003f3e76a","v":"1c6b9bbb697af10c10841daf2f66c34f35119df99210f0a217d7576641a3c4bd","K":"12441330761073902362665870877411039194406913991527867894825343377465888911436.46098634706424153770461318034056899255536118904510923943565444055909322001987","V":"8102025673725356318677291182437916572141609255897970301275085776048145857154.556392429964288978869362748540071319936808983044189432587667189241665581092"}
jsonInputString:: {"K":"12441330761073902362665870877411039194406913991527867894825343377465888911436.46098634706424153770461318034056899255536118904510923943565444055909322001987","V":"8102025673725356318677291182437916572141609255897970301275085776048145857154.556392429964288978869362748540071319936808983044189432587667189241665581092"}
SenderInputData {K:12441330761073902362665870877411039194406913991527867894825343377465888911436.46098634706424153770461318034056899255536118904510923943565444055909322001987 V:8102025673725356318677291182437916572141609255897970301275085776048145857154.556392429964288978869362748540071319936808983044189432587667189241665581092}
{
  r: '7765146151407214036795295172855103047881555505452604803034314956426654468821',
  R: '16656989775241115616961842498057993371454390893570465587720101669655905255969.13380829724445603997021653048859810323898205122488578229797007091787893906124',
  viewTag: '16',
  spendingPubKey: '36745627561581476921521509282161954132227930892779041084029164927930889751109.88680597906945505561522874092218533356775236933856020631319132133904212431487'
}
{"k":"1072809b97a3f1dbeab2142394e224c69171c0943afbfefd8e0661b003f3e76a","v":"1c6b9bbb697af10c10841daf2f66c34f35119df99210f0a217d7576641a3c4bd","Rs":["16656989775241115616961842498057993371454390893570465587720101669655905255969.13380829724445603997021653048859810323898205122488578229797007091787893906124"],"viewTags":["16"]}
recipientInputData {1072809b97a3f1dbeab2142394e224c69171c0943afbfefd8e0661b003f3e76a 1c6b9bbb697af10c10841daf2f66c34f35119df99210f0a217d7576641a3c4bd [16656989775241115616961842498057993371454390893570465587720101669655905255969.13380829724445603997021653048859810323898205122488578229797007091787893906124] [16]}
calculatedViewTag 16
{
  spendingPubKeys: [
    '36745627561581476921521509282161954132227930892779041084029164927930889751109.88680597906945505561522874092218533356775236933856020631319132133904212431487'
  ],
  spendingPrivKeys: [
    '0xec98ef33fb6ec0967d4fb37caecca818456f7e09adb850db989344eebb5acb91'
  ]
}
{ validPointRes: true }
{ secp2561ValidPointRes: true }
```